### PR TITLE
Fix artifact name format in Build.yml

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: DownloadFullInstaller-2${{ env.GIT_SHA }}
+          name: DownloadFullInstaller-2-${{ env.GIT_SHA }}
           path: |
             build/Release.tar


### PR DESCRIPTION
This will separate the archive name DownloadFullInstaller-2 with a `-`